### PR TITLE
fix: validate that provided root types exist

### DIFF
--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/alecthomas/kong v1.12.1
 	github.com/alecthomas/kong-toml v0.4.0
 	github.com/alecthomas/zero v0.0.0-00010101000000-000000000000
+	golang.org/x/sync v0.16.0
 )
 
 require (
@@ -35,7 +36,6 @@ require (
 	go.jetify.com/typeid/v2 v2.0.0-alpha.3 // indirect
 	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
-	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 	modernc.org/libc v1.66.3 // indirect

--- a/_examples/service/zero.go
+++ b/_examples/service/zero.go
@@ -3,7 +3,6 @@ package main
 
 import (
   "database/sql"
-  "log/slog"
   "context"
   "fmt"
   "github.com/alecthomas/zero"
@@ -17,6 +16,7 @@ import (
   imp9b258f273adc01df "github.com/alecthomas/zero/providers/leases"
   imp9c34c006eb3c10fa "github.com/alecthomas/zero"
   impc24ab568b6f3f934 "github.com/alecthomas/zero/providers/sql"
+  "log/slog"
   "net/http"
   "reflect"
   "time"
@@ -51,10 +51,12 @@ func RegisterHandlers(ctx context.Context, injector *Injector) error {
 	if err != nil {
 		return err
 	}
+	_ = mux
 	logger, err := ZeroConstructSingletons[*slog.Logger](ctx, injector)
 	if err != nil {
 		return err
 	}
+	_ = logger
 	encodeError, err := ZeroConstructSingletons[zero.ErrorEncoder](ctx, injector)
 	if err != nil {
 		return err
@@ -263,15 +265,19 @@ func ZeroConstructSingletons[T any](ctx context.Context, injector *Injector) (ou
 		if err != nil {
 			return out, err
 		}
-		p1, err := ZeroConstructSingletons[imp3773070ca4e7a2b8.Config](ctx, injector)
+		p1, err := ZeroConstructSingletons[*slog.Logger](ctx, injector)
 		if err != nil {
 			return out, err
 		}
-		p2, err := ZeroConstructSingletons[*http.ServeMux](ctx, injector)
+		p2, err := ZeroConstructSingletons[imp3773070ca4e7a2b8.Config](ctx, injector)
 		if err != nil {
 			return out, err
 		}
-		o := imp3773070ca4e7a2b8.DefaultServer(p0, p1, p2)
+		p3, err := ZeroConstructSingletons[*http.ServeMux](ctx, injector)
+		if err != nil {
+			return out, err
+		}
+		o := imp3773070ca4e7a2b8.DefaultServer(p0, p1, p2, p3)
 		return any(o).(T), nil
 
 	case reflect.TypeOf((*imp9c34c006eb3c10fa.ErrorEncoder)(nil)).Elem():

--- a/internal/depgraph/depgraph_middleware_labels_test.go
+++ b/internal/depgraph/depgraph_middleware_labels_test.go
@@ -16,6 +16,11 @@ import (
 	"net/http"
 )
 
+//zero:provider
+func ProvideDAL() *DAL {
+	return &DAL{}
+}
+
 type DAL struct{}
 
 //zero:middleware authenticated
@@ -39,7 +44,7 @@ func AuthWithRole(admin string, moderator int, dal *DAL) func(http.Handler) http
 
 `
 
-	graph := analyseTestCode(t, testCode, []string{"string"})
+	graph := analyseTestCode(t, testCode, nil)
 
 	// Should have 2 middlewares
 	assert.Equal(t, 2, len(graph.Middleware))
@@ -98,7 +103,7 @@ func Auth(wrongName string, dal *DAL) func(http.Handler) http.Handler {
 
 `
 
-	_, err := analyseTestCodeWithError(t, testCode, []string{"string"})
+	_, err := analyseTestCodeWithError(t, testCode, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "parameter wrongName of type string in middleware Auth must match a label name")
 }
@@ -111,6 +116,21 @@ package main
 import (
 	"net/http"
 )
+
+//zero:provider
+func ProvideString() string {
+	return "test"
+}
+
+//zero:provider
+func ProvideDAL() *DAL {
+	return &DAL{}
+}
+
+//zero:provider
+func ProvideLogger() *Logger {
+	return &Logger{}
+}
 
 type DAL struct{}
 type Logger struct{}
@@ -168,6 +188,11 @@ import (
 	"net/http"
 )
 
+//zero:provider
+func ProvideString() string {
+	return "test"
+}
+
 //zero:middleware cors
 func CORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -179,6 +204,7 @@ func CORS(next http.Handler) http.Handler {
 
 	graph := analyseTestCode(t, testCode, []string{"string"})
 
+	assert.Equal(t, []string{"string"}, stableKeys(graph.Providers))
 	// Should have 1 middleware
 	assert.Equal(t, 1, len(graph.Middleware))
 
@@ -199,6 +225,16 @@ package main
 import (
 	"net/http"
 )
+
+//zero:provider
+func ProvideString() string {
+	return "test"
+}
+
+//zero:provider
+func ProvideCache() *Cache {
+	return &Cache{}
+}
 
 type Cache struct{}
 

--- a/internal/depgraph/depgraph_middleware_pruning_test.go
+++ b/internal/depgraph/depgraph_middleware_pruning_test.go
@@ -17,6 +17,11 @@ import (
 
 type Service struct{}
 
+//zero:provider
+func NewService() *Service {
+	return &Service{}
+}
+
 // Global middleware - no labels, should always be kept
 //zero:middleware
 func GlobalMiddleware() func(http.Handler) http.Handler {
@@ -102,6 +107,11 @@ import (
 
 type Service struct{}
 
+//zero:provider
+func NewService() *Service {
+	return &Service{}
+}
+
 // Middleware with multiple labels - should be kept if ANY label matches
 //zero:middleware cache timeout
 func CacheMiddleware() func(http.Handler) http.Handler {
@@ -145,9 +155,13 @@ import (
 	"net/http"
 )
 
+//zero:provider
+func ProvideString() string {
+	return "test"
+}
+
 //zero:middleware test
 func TestMiddleware() func(http.Handler) http.Handler {
-t.Parallel()
 	return func(next http.Handler) http.Handler {
 		return next
 	}
@@ -177,6 +191,11 @@ import (
 )
 
 type Service struct{}
+
+//zero:provider
+func NewService() *Service {
+	return &Service{}
+}
 
 // Middleware with empty label (should be treated as global)
 //zero:middleware
@@ -235,6 +254,11 @@ import (
 )
 
 type Service struct{}
+
+//zero:provider
+func NewService() *Service {
+	return &Service{}
+}
 
 // Middleware that should match label name regardless of value
 //zero:middleware cache

--- a/internal/depgraph/depgraph_user_case_test.go
+++ b/internal/depgraph/depgraph_user_case_test.go
@@ -2,6 +2,7 @@ package depgraph
 
 import (
 	"go/types"
+	"slices"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -28,7 +29,7 @@ func Auth(authenticated string, dal *DAL) func(http.Handler) http.Handler {
 }
 `
 
-	graph := analyseTestCode(t, testCode, []string{"string"})
+	graph := analyseTestCode(t, testCode, nil)
 
 	// Should have 1 middleware
 	assert.Equal(t, 1, len(graph.Middleware))
@@ -70,7 +71,7 @@ func ComplexAuth(role string, level int, authenticated string, dal *DAL, logger 
 }
 `
 
-	graph := analyseTestCode(t, testCode, []string{"string"})
+	graph := analyseTestCode(t, testCode, nil)
 
 	// Should have 1 middleware
 	assert.Equal(t, 1, len(graph.Middleware))
@@ -91,13 +92,7 @@ func ComplexAuth(role string, level int, authenticated string, dal *DAL, logger 
 
 	expectedTypes := []string{"*test.DAL", "*test.Logger", "*test.Cache"}
 	for _, expected := range expectedTypes {
-		found := false
-		for _, actual := range requiredTypes {
-			if actual == expected {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(requiredTypes, expected)
 		assert.True(t, found, "Expected to find required type %s", expected)
 	}
 


### PR DESCRIPTION
This was a fairly consistent source of bugs and, in fact, revealed a bunch of bugs in the tests, which are also fixed.